### PR TITLE
Update url into `raw.githubusercontent.com`

### DIFF
--- a/background.js
+++ b/background.js
@@ -9,7 +9,7 @@ chrome.webRequest.onHeadersReceived.addListener(
 
 	    return {responseHeaders:details.responseHeaders};
 	},
-	{urls: ['https://raw.github.com/*.html']},
+	{urls: ['https://raw.githubusercontent.com/*.html']},
 	['blocking', 'responseHeaders']
 );
 
@@ -21,7 +21,7 @@ chrome.webRequest.onHeadersReceived.addListener(
 
 	    return {responseHeaders:details.responseHeaders};
 	},
-	{urls: ['https://raw.github.com/*.js']},
+	{urls: ['https://raw.githubusercontent.com/*.js']},
 	['blocking', 'responseHeaders']
 );
 
@@ -34,6 +34,6 @@ chrome.webRequest.onHeadersReceived.addListener(
 
     	return {responseHeaders:details.responseHeaders};
 	},
-	{urls: ['https://raw.github.com/*.css']},
+	{urls: ['https://raw.githubusercontent.com/*.css']},
 	['blocking', 'responseHeaders']
 );

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "version": "0.1",
   "incognito": "split",
   "permissions": [
-    "https://raw.github.com/*",
+    "https://raw.githubusercontent.com/*",
     "webRequest",
     "webRequestBlocking"
   ],


### PR DESCRIPTION
The chrome extension currently no longer works, because **raw.github.com** is now a different url.

This pull request fixes that.